### PR TITLE
Update make:console to make:command and add make:mail

### DIFF
--- a/Laravel 5 Artisan.sublime-commands
+++ b/Laravel 5 Artisan.sublime-commands
@@ -177,6 +177,15 @@
         }
     },
     {
+        "caption": "Laravel Artisan 5: Make:Mail",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:mail",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the mailable class"
+        }
+    },
+    {
         "caption": "Laravel Artisan 5: Make:Middleware",
         "command": "laravel5_artisan",
         "args": {

--- a/Laravel 5 Artisan.sublime-commands
+++ b/Laravel 5 Artisan.sublime-commands
@@ -132,10 +132,10 @@
         }
     },
     {
-        "caption": "Laravel Artisan 5: Make:Console",
+        "caption": "Laravel Artisan 5: Make:Command",
         "command": "laravel5_artisan",
         "args": {
-            "command": "make:console",
+            "command": "make:command",
             "fill_in": true,
             "fill_in_lable": "Enter the name of the command class"
         }


### PR DESCRIPTION
This pull request:
 * updates the make:console command to make:command, as this is the current syntax.
 * adds a new make:mail command to create a new mailable.


If pull request is accepted, I can look into more commands to update.

Thank you!
Let me know if anything.