### PR TITLE
Add missing make commands + migrate fresh, & update readme

### DIFF
--- a/Laravel 5 Artisan.sublime-commands
+++ b/Laravel 5 Artisan.sublime-commands
@@ -132,6 +132,15 @@
         }
     },
     {
+        "caption": "Laravel Artisan 5: Make:Channel",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:channel",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the channel class"
+        }
+    },
+    {
         "caption": "Laravel Artisan 5: Make:Command",
         "command": "laravel5_artisan",
         "args": {
@@ -156,6 +165,24 @@
             "command": "make:event",
             "fill_in": true,
             "fill_in_lable": "Enter the name of the event class"
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Make:Exception",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:exception",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the exception class"
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Make:Factory",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:factory",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the factory class"
         }
     },
     {
@@ -233,6 +260,33 @@
         }
     },
     {
+        "caption": "Laravel Artisan 5: Make:Notification",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:notification",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the notification class"
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Make:Observer",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:observer",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the observer class"
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Make Policy",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:policy",
+            "fill_in": true,
+            "fill_in_lable": "Enter the Policy name"
+        }
+    },
+    {
         "caption": "Laravel Artisan 5: Make:Provider",
         "command": "laravel5_artisan",
         "args": {
@@ -248,6 +302,24 @@
             "command": "make:request",
             "fill_in": true,
             "fill_in_lable": "Enter the name of the request"
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Make:Resource",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:resource",
+            "fill_in": true,
+            "fill_in_lable": "Enter the name of the resource"
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Make Rule",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "make:rule",
+            "fill_in": true,
+            "fill_in_lable": "Enter the rule name"
         }
     },
     {
@@ -276,7 +348,14 @@
         }
     },
     {
-        "caption": "Laravel Artisan 5: Migrate:Refresh",
+        "caption": "Laravel Artisan 5: Migrate:Fresh (Drop all tables and re-run all migrations)",
+        "command": "laravel5_artisan",
+        "args": {
+            "command": "migrate:fresh",
+        }
+    },
+    {
+        "caption": "Laravel Artisan 5: Migrate:Refresh (Reset and re-run all migrations)",
         "command": "laravel5_artisan",
         "args": {
             "command": "migrate:refresh"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Several of the commands, such as `Laravel Artisan: Make: Migration Schema` requi
 - `Laravel Artisan 5: Key:Generate`
 
 ##### Make
+- `Laravel Artisan 5: Make:Command`
 - `Laravel Artisan 5: Make:Controller`
 - `Laravel Artisan 5: Make:Event`
+- `Laravel Artisan 5: Make:Mail`
 - `Laravel Artisan 5: Make:Middleware`
 - `Laravel Artisan 5: Make:Migration`
 - `Laravel Generate 5: Make:Migration: Schema`

--- a/README.md
+++ b/README.md
@@ -43,20 +43,31 @@ Several of the commands, such as `Laravel Artisan: Make: Migration Schema` requi
 - `Laravel Artisan 5: Key:Generate`
 
 ##### Make
+- `Laravel Artisan 5: Make:Auth`
+- `Laravel Artisan 5: Make:Channel`
 - `Laravel Artisan 5: Make:Command`
 - `Laravel Artisan 5: Make:Controller`
 - `Laravel Artisan 5: Make:Event`
+- `Laravel Artisan 5: Make:Exception`
+- `Laravel Artisan 5: Make:Factory`
+- `Laravel Artisan 5: Make:Job`
+- `Laravel Artisan 5: Make:Listener`
 - `Laravel Artisan 5: Make:Mail`
 - `Laravel Artisan 5: Make:Middleware`
 - `Laravel Artisan 5: Make:Migration`
 - `Laravel Generate 5: Make:Migration: Schema`
 - `Laravel Generate 5: Make:Migration: Pivot`
 - `Laravel Artisan 5: Make:Model`
+- `Laravel Artisan 5: Make:Notification`
+- `Laravel Artisan 5: Make:Observer`
 - `Laravel Artisan 5: Make:Provider`
 - `Laravel Artisan 5: Make:Request`
+- `Laravel Artisan 5: Make:Resource`
 - `Laravel Artisan 5: Make:Seeder`
+- `Laravel Artisan 5: Make:Test`
 
 ##### Migrate
+- `Laravel Artisan 5: Migrate:Fresh`
 - `Laravel Artisan 5: Migrate:Install`
 - `Laravel Artisan 5: Migrate:Refresh`
 - `Laravel Artisan 5: Migrate:Reset`


### PR DESCRIPTION
This pull request
 * adds all missing make commands
 * adds migrate fresh (including description in name to avoid mistakes between fresh / refresh)
 * adds the new commands to the readme file

Could you please tag a new version after merging, so these can be updated  in sublime?
Thank you!